### PR TITLE
feat: trigger release on PR merge

### DIFF
--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -1,10 +1,12 @@
 name: Create Tag and Release on push
 
 on:
+  pull_request:
+    types: [closed]
+
   push:
     branches:
       - main
-      - release/*
 
 jobs:
   create-release:


### PR DESCRIPTION
The workflow now triggers a release on pull request merge. This simplifies the release process by automating the creation of release tags and drafts. This removes the manual steps involved in releasing and ensures releases are always created in a consistent manner.